### PR TITLE
feat(pacientes): implementa endpoints CRUD para pacientes

### DIFF
--- a/cmd/patients/create/create.go
+++ b/cmd/patients/create/create.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/MezeLaw/iris-services/internal/handler"
+	"github.com/MezeLaw/iris-services/internal/models"
+	"github.com/MezeLaw/iris-services/internal/repository"
+	"github.com/MezeLaw/iris-services/internal/service"
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"go.uber.org/zap"
+	"time"
+)
+
+func main() {
+	logger, _ := zap.NewProduction()
+	sugar := logger.Sugar()
+
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	if err != nil {
+		sugar.Fatalf("error loading AWS config: %v", err)
+	}
+	dynamoClient := dynamodb.NewFromConfig(cfg)
+
+	repo := repository.New(dynamoClient, sugar, "PatientsTable", "client_id_index", "doc_key_index")
+	svc := service.New(sugar, repo)
+	h := handler.New(svc, sugar)
+
+	lambda.Start(func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+		var request models.PatientRequest
+		if err := json.Unmarshal([]byte(req.Body), &request); err != nil {
+			sugar.Errorf("Error unmarshalling request: %v", err.Error())
+			return events.APIGatewayProxyResponse{StatusCode: 400, Body: `{"error":"invalid request body"}`}, nil
+		}
+
+		now := time.Now().Format(time.RFC3339)
+		request.CreatedAt = now
+		request.UpdatedAt = now
+
+		created, err := h.Create(ctx, &request)
+		if err != nil {
+			sugar.Errorf("Error creating patient: %v", err.Error())
+			return events.APIGatewayProxyResponse{StatusCode: 500, Body: `{"error":"could not create patient"}`}, nil
+		}
+
+		respBody, _ := json.Marshal(created)
+		return events.APIGatewayProxyResponse{
+			StatusCode: 201,
+			Body:       string(respBody),
+			Headers:    map[string]string{"Content-Type": "application/json"},
+		}, nil
+	})
+}

--- a/cmd/patients/delete/delete.go
+++ b/cmd/patients/delete/delete.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+
+	"github.com/MezeLaw/iris-services/internal/handler"
+	"github.com/MezeLaw/iris-services/internal/repository"
+	"github.com/MezeLaw/iris-services/internal/service"
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"go.uber.org/zap"
+)
+
+func main() {
+	logger, _ := zap.NewProduction()
+	sugar := logger.Sugar()
+
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	if err != nil {
+		sugar.Fatalf("error loading AWS config: %v", err)
+	}
+	dynamoClient := dynamodb.NewFromConfig(cfg)
+
+	repo := repository.New(dynamoClient, sugar, "PatientsTable", "client_id_index", "doc_key_index")
+	svc := service.New(sugar, repo)
+	h := handler.New(svc, sugar)
+
+	lambda.Start(func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+		patientID := req.QueryStringParameters["id"]
+		if patientID == "" {
+			sugar.Error("Missing patient ID in delete request")
+			return events.APIGatewayProxyResponse{StatusCode: 400, Body: `{"error":"patient ID is required for deletion"}`}, nil
+		}
+
+		err := h.Delete(ctx, patientID)
+		if err != nil {
+			sugar.Errorf("Error deleting patient: %v", err.Error())
+			return events.APIGatewayProxyResponse{StatusCode: 500, Body: `{"error":"could not delete patient"}`}, nil
+		}
+
+		return events.APIGatewayProxyResponse{
+			StatusCode: 204,
+			Headers:    map[string]string{"Content-Type": "application/json"},
+		}, nil
+	})
+}

--- a/cmd/patients/get/get.go
+++ b/cmd/patients/get/get.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/MezeLaw/iris-services/internal/handler"
+	"github.com/MezeLaw/iris-services/internal/models"
+	"github.com/MezeLaw/iris-services/internal/repository"
+	"github.com/MezeLaw/iris-services/internal/service"
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"go.uber.org/zap"
+)
+
+func main() {
+	logger, _ := zap.NewProduction()
+	sugar := logger.Sugar()
+
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	if err != nil {
+		sugar.Fatalf("error loading AWS config: %v", err)
+	}
+	dynamoClient := dynamodb.NewFromConfig(cfg)
+
+	repo := repository.New(dynamoClient, sugar, "PatientsTable", "client_id_index", "doc_key_index")
+	svc := service.New(sugar, repo)
+	h := handler.New(svc, sugar)
+
+	lambda.Start(func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+		patientID := req.QueryStringParameters["id"]
+		docType := req.QueryStringParameters["docType"]
+		docNumber := req.QueryStringParameters["docNumber"]
+
+		if patientID == "" && (docType == "" || docNumber == "") {
+			sugar.Errorf("Missing required parameters in request")
+			return events.APIGatewayProxyResponse{StatusCode: 400, Body: `{"error":"missing required parameters"}`}, nil
+		}
+
+		request := &models.GetPatientRequest{
+			ID:        patientID,
+			DocType:   docType,
+			DocNumber: docNumber,
+		}
+
+		patient, err := h.Get(ctx, request)
+		if err != nil {
+			sugar.Errorf("Error retrieving patient: %v", err.Error())
+			return events.APIGatewayProxyResponse{StatusCode: 500, Body: `{"error":"could not retrieve patient"}`}, nil
+		}
+
+		respBody, _ := json.Marshal(patient)
+		return events.APIGatewayProxyResponse{
+			StatusCode: 200,
+			Body:       string(respBody),
+			Headers:    map[string]string{"Content-Type": "application/json"},
+		}, nil
+	})
+}

--- a/cmd/patients/getAll/get_all.go
+++ b/cmd/patients/getAll/get_all.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/MezeLaw/iris-services/internal/handler"
+	"github.com/MezeLaw/iris-services/internal/repository"
+	"github.com/MezeLaw/iris-services/internal/service"
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"go.uber.org/zap"
+)
+
+func main() {
+	logger, _ := zap.NewProduction()
+	sugar := logger.Sugar()
+
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	if err != nil {
+		sugar.Fatalf("error loading AWS config: %v", err)
+	}
+	dynamoClient := dynamodb.NewFromConfig(cfg)
+
+	repo := repository.New(dynamoClient, sugar, "PatientsTable", "client_id_index", "doc_key_index")
+	svc := service.New(sugar, repo)
+	h := handler.New(svc, sugar)
+
+	lambda.Start(func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+		clientID := req.QueryStringParameters["clientId"]
+		if clientID == "" {
+			sugar.Error("Missing clientId parameter in request")
+			return events.APIGatewayProxyResponse{StatusCode: 400, Body: `{"error":"missing clientId parameter"}`}, nil
+		}
+
+		patients, err := h.GetAll(ctx, clientID)
+		if err != nil {
+			sugar.Errorf("Error retrieving patients: %v", err)
+			return events.APIGatewayProxyResponse{StatusCode: 500, Body: `{"error":"could not retrieve patients"}`}, nil
+		}
+
+		respBody, _ := json.Marshal(patients)
+		return events.APIGatewayProxyResponse{
+			StatusCode: 200,
+			Body:       string(respBody),
+			Headers:    map[string]string{"Content-Type": "application/json"},
+		}, nil
+	})
+}

--- a/cmd/patients/update/update.go
+++ b/cmd/patients/update/update.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+
+	"time"
+
+	"github.com/MezeLaw/iris-services/internal/handler"
+	"github.com/MezeLaw/iris-services/internal/models"
+	"github.com/MezeLaw/iris-services/internal/repository"
+	"github.com/MezeLaw/iris-services/internal/service"
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"go.uber.org/zap"
+)
+
+func main() {
+	logger, _ := zap.NewProduction()
+	sugar := logger.Sugar()
+
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	if err != nil {
+		sugar.Fatalf("error loading AWS config: %v", err)
+	}
+	dynamoClient := dynamodb.NewFromConfig(cfg)
+
+	repo := repository.New(dynamoClient, sugar, "PatientsTable", "client_id_index", "doc_key_index")
+	svc := service.New(sugar, repo)
+	h := handler.New(svc, sugar)
+
+	lambda.Start(func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+		var request models.PatientRequest
+		if err := json.Unmarshal([]byte(req.Body), &request); err != nil {
+			sugar.Errorf("Error unmarshalling request: %v", err.Error())
+			return events.APIGatewayProxyResponse{StatusCode: 400, Body: `{"error":"invalid request body"}`}, nil
+		}
+
+		// Ensure ID is provided for update
+		if request.ID == "" {
+			sugar.Error("Missing patient ID in update request")
+			return events.APIGatewayProxyResponse{StatusCode: 400, Body: `{"error":"patient ID is required for update"}`}, nil
+		}
+
+		// Set update timestamp
+		request.UpdatedAt = time.Now().Format(time.RFC3339)
+
+		updated, err := h.Update(ctx, &request)
+		if err != nil {
+			sugar.Errorf("Error updating patient: %v", err.Error())
+			return events.APIGatewayProxyResponse{StatusCode: 500, Body: `{"error":"could not update patient"}`}, nil
+		}
+
+		respBody, _ := json.Marshal(updated)
+		return events.APIGatewayProxyResponse{
+			StatusCode: 200,
+			Body:       string(respBody),
+			Headers:    map[string]string{"Content-Type": "application/json"},
+		}, nil
+	})
+}


### PR DESCRIPTION
## Descripción
Se implementan los endpoints CRUD para el manejo de pacientes, organizando cada operación en su propio handler Lambda.

### Cambios Realizados
- Agrega endpoint de creación de pacientes (`/cmd/patients/create`)
- Agrega endpoint de obtención de paciente por ID o documento (`/cmd/patients/get`)
- Agrega endpoint de listado de pacientes por clientId (`/cmd/patients/getAll`)
- Agrega endpoint de actualización de pacientes (`/cmd/patients/update`)
- Agrega endpoint de eliminación de pacientes (`/cmd/patients/delete`)

### Estructura
Cada endpoint está implementado como una función Lambda independiente, siguiendo la estructura de capas:
- Handler: Manejo de requests/responses HTTP
- Service: Lógica de negocio
- Repository: Acceso a datos en DynamoDB

### Testing
Los tests existentes en las capas de servicio, handler y repositorio cubren la funcionalidad implementada.

### Notas Adicionales
- Se mantiene consistencia en el manejo de errores y logging
- Se utiliza el mismo formato de respuesta HTTP en todos los endpoints
- Se validan los parámetros requeridos en cada operación