### PR TITLE
feat(citas): implementa endpoint de creación de citas

### DIFF
--- a/cmd/appointments/create/create.go
+++ b/cmd/appointments/create/create.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/MezeLaw/iris-services/internal/handler"
+	"github.com/MezeLaw/iris-services/internal/models"
+	"github.com/MezeLaw/iris-services/internal/repository"
+	"github.com/MezeLaw/iris-services/internal/service"
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"go.uber.org/zap"
+	"time"
+)
+
+func main() {
+	logger, _ := zap.NewProduction()
+	sugar := logger.Sugar()
+
+	cfg, err := config.LoadDefaultConfig(context.Background())
+	if err != nil {
+		sugar.Fatalf("error loading AWS config: %v", err)
+	}
+	dynamoClient := dynamodb.NewFromConfig(cfg)
+
+	repo := repository.New(dynamoClient, sugar, "AppointmentsTable", "client_id_index", "doc_key_index")
+	svc := service.New(sugar, repo)
+	h := handler.New(svc, sugar)
+
+	lambda.Start(func(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+		var request models.AppointmentRequest
+		if err := json.Unmarshal([]byte(req.Body), &request); err != nil {
+			sugar.Errorf("Error unmarshalling request: %v", err.Error())
+			return events.APIGatewayProxyResponse{StatusCode: 400, Body: `{"error":"invalid request body"}`}, nil
+		}
+
+		now := time.Now().Format(time.RFC3339)
+		request.CreatedAt = now
+		request.UpdatedAt = now
+
+		created, err := h.Create(ctx, &request)
+		if err != nil {
+			sugar.Errorf("Error creating appointment: %v", err.Error())
+			return events.APIGatewayProxyResponse{StatusCode: 500, Body: `{"error":"could not create appointment"}`}, nil
+		}
+
+		respBody, _ := json.Marshal(created)
+		return events.APIGatewayProxyResponse{
+			StatusCode: 201,
+			Body:       string(respBody),
+			Headers:    map[string]string{"Content-Type": "application/json"},
+		}, nil
+	})
+}


### PR DESCRIPTION
## Descripción
Implementa el endpoint para la creación de citas médicas.

### Características Implementadas
- Handler Lambda para creación de citas
- Integración con DynamoDB para almacenamiento de citas
- Validación de datos de entrada
- Manejo consistente de errores
- Logging estructurado con Zap
- Timestamps automáticos de creación y actualización

### Estructura
- Nuevo endpoint en `/cmd/appointments/create`
- Reutilización de la arquitectura en capas existente

### Validaciones
- Verifica el formato del request body
- Manejo de errores HTTP apropiados (400 para requests inválidos, 500 para errores internos)
- Respuestas HTTP consistentes con el resto de la API

### Notas Técnicas
- Mismo patrón de implementación que los endpoints de pacientes
- Utiliza la infraestructura de logging existente
- Formato de respuesta estandarizado