### PR TITLE
feat: Add support for non-binary gender and validation

### DIFF
--- a/internal/handler/patients/patients.go
+++ b/internal/handler/patients/patients.go
@@ -1,0 +1,95 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MezeLaw/iris-services/internal/models"
+	"go.uber.org/zap"
+)
+
+type PatientsHandler interface {
+	Create(context.Context, *models.PatientRequest) (*models.PatientRequest, error)
+	Get(ctx context.Context, getPatient *models.GetPatientRequest) (*models.PatientRequest, error)
+	GetAll(ctx context.Context, clientID string) ([]*models.PatientRequest, error)
+	Update(ctx context.Context, patient *models.PatientRequest) (*models.PatientRequest, error)
+	Delete(ctx context.Context, userID string) error
+}
+
+type PatientsService interface {
+	CreatePatient(context.Context, *models.PatientRequest) (*models.PatientRequest, error)
+	GetPatient(context.Context, *models.GetPatientRequest) (*models.PatientRequest, error)
+	GetAllPatients(context.Context, string) ([]*models.PatientRequest, error)
+	UpdatePatient(context.Context, *models.PatientRequest) error
+	DeletePatient(context.Context, string) error
+}
+
+type Patients struct {
+	Service PatientsService
+	Logger  *zap.SugaredLogger
+}
+
+func New(service PatientsService, logger *zap.SugaredLogger) PatientsHandler {
+	return &Patients{Service: service, Logger: logger}
+}
+
+func (p *Patients) Create(ctx context.Context, patient *models.PatientRequest) (*models.PatientRequest, error) {
+	p.Logger.Infof("Creating patient: %s", patient)
+	if patient.Gender != models.GenderMale && patient.Gender != models.GenderFemale && patient.Gender != models.GenderNonBinary {
+		err := fmt.Errorf("invalid gender value: %s. Must be one of: %s, %s, %s", patient.Gender, models.GenderMale, models.GenderFemale, models.GenderNonBinary)
+		p.Logger.Error(err)
+		return nil, err
+	}
+	result, err := p.Service.CreatePatient(ctx, patient)
+	if err != nil {
+		p.Logger.Errorf("Error creating patient: %s", err)
+		return nil, err
+	}
+	return result, nil
+}
+
+func (p *Patients) Get(ctx context.Context, getRequest *models.GetPatientRequest) (*models.PatientRequest, error) {
+	p.Logger.Infof("Getting patient with params: %s", getRequest)
+	result, err := p.Service.GetPatient(ctx, getRequest)
+	if err != nil {
+		p.Logger.Errorf("Error getting patient: %s", err)
+		return nil, err
+	}
+	return result, nil
+}
+
+func (p *Patients) GetAll(ctx context.Context, clientID string) ([]*models.PatientRequest, error) {
+	p.Logger.Infof("Getting all patients with clientID: %s", clientID)
+	result, err := p.Service.GetAllPatients(ctx, clientID)
+	if err != nil {
+		p.Logger.Errorf("Error getting patients by clientId: %s", err)
+		return nil, err
+	}
+	return result, nil
+}
+
+func (p *Patients) Update(ctx context.Context, patient *models.PatientRequest) (*models.PatientRequest, error) {
+	p.Logger.Infof("Updating patient: %s", patient)
+	if patient.Gender != models.GenderMale && patient.Gender != models.GenderFemale && patient.Gender != models.GenderNonBinary {
+		err := fmt.Errorf("invalid gender value: %s. Must be one of: %s, %s, %s", patient.Gender, models.GenderMale, models.GenderFemale, models.GenderNonBinary)
+		p.Logger.Error(err)
+		return nil, err
+	}
+	err := p.Service.UpdatePatient(ctx, patient)
+	if err != nil {
+		p.Logger.Errorf("Error updating patient: %s", err)
+		return nil, err
+	}
+	// Return the updated patient data
+	return patient, nil
+}
+
+func (p *Patients) Delete(ctx context.Context, userID string) error {
+	p.Logger.Infof("Deleting patient with userID: %s", userID)
+	err := p.Service.DeletePatient(ctx, userID)
+	if err != nil {
+		p.Logger.Errorf("Error deleting patient: %s", err)
+		return err
+	}
+	return nil
+}

--- a/internal/handler/patients/patients_test.go
+++ b/internal/handler/patients/patients_test.go
@@ -1,0 +1,432 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MezeLaw/iris-services/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap/zaptest"
+)
+
+// MockPatientsService implementa la interfaz PatientsService para los tests
+type MockPatientsService struct {
+	mock.Mock
+}
+
+func (m *MockPatientsService) CreatePatient(ctx context.Context, patient *models.PatientRequest) (*models.PatientRequest, error) {
+	args := m.Called(ctx, patient)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.PatientRequest), args.Error(1)
+}
+
+func (m *MockPatientsService) GetPatient(ctx context.Context, req *models.GetPatientRequest) (*models.PatientRequest, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.PatientRequest), args.Error(1)
+}
+
+func (m *MockPatientsService) GetAllPatients(ctx context.Context, clientID string) ([]*models.PatientRequest, error) {
+	args := m.Called(ctx, clientID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.PatientRequest), args.Error(1)
+}
+
+func (m *MockPatientsService) UpdatePatient(ctx context.Context, patient *models.PatientRequest) error {
+	args := m.Called(ctx, patient)
+	return args.Error(0)
+}
+
+func (m *MockPatientsService) DeletePatient(ctx context.Context, id string) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func TestNew(t *testing.T) {
+	// Arrange
+	logger := zaptest.NewLogger(t).Sugar()
+	mockService := new(MockPatientsService)
+
+	// Act
+	handler := New(mockService, logger)
+
+	// Assert
+	assert.NotNil(t, handler)
+	assert.IsType(t, &Patients{}, handler)
+}
+
+func TestPatients_Create(t *testing.T) {
+	// Sample patient for tests
+	samplePatient := &models.PatientRequest{
+		ClientID:       "client123",
+		FirstName:      "John",
+		LastName:       "Doe",
+		DocType:        "DNI",
+		DocNumber:      "12345678",
+		BirthDate:      "1990-01-01",
+		Gender:         "M",
+		CountryCode:    "54",
+		PhoneNumber:    "1234567890",
+		Email:          "john.doe@example.com",
+		AddressStreet:  "Main St",
+		AddressNumber:  "123",
+		AddressCity:    "City",
+		AddressCountry: "Country",
+		ZipCode:        "12345",
+		Metadata:       map[string]interface{}{"key": "value"},
+	}
+
+	errorPatient := &models.PatientRequest{
+		ClientID:       "client456",
+		FirstName:      "Jane",
+		LastName:       "Smith",
+		DocType:        "DNI",
+		DocNumber:      "87654321",
+		BirthDate:      "1995-05-05",
+		Gender:         "F",
+		CountryCode:    "54",
+		PhoneNumber:    "9876543210",
+		Email:          "jane.smith@example.com",
+		AddressStreet:  "Second St",
+		AddressNumber:  "456",
+		AddressCity:    "Another City",
+		AddressCountry: "Another Country",
+		ZipCode:        "54321",
+		Metadata:       map[string]interface{}{"key2": "value2"},
+	}
+
+	// Test scenarios
+	tests := []struct {
+		name           string
+		patient        *models.PatientRequest
+		mockSetup      func(*MockPatientsService, *models.PatientRequest)
+		expectedError  error
+		expectedResult *models.PatientRequest
+	}{
+		{
+			name:    "Success",
+			patient: samplePatient,
+			mockSetup: func(m *MockPatientsService, p *models.PatientRequest) {
+				m.On("CreatePatient", mock.Anything, p).Return(p, nil)
+			},
+			expectedError:  nil,
+			expectedResult: samplePatient,
+		},
+		{
+			name:    "Service Error",
+			patient: errorPatient,
+			mockSetup: func(m *MockPatientsService, p *models.PatientRequest) {
+				m.On("CreatePatient", mock.Anything, p).Return(nil, errors.New("service error"))
+			},
+			expectedError:  errors.New("service error"),
+			expectedResult: nil,
+		},
+		{
+			name: "Validation Error",
+			patient: &models.PatientRequest{
+				// Incomplete patient data
+				ClientID:  "client789",
+				FirstName: "Incomplete",
+			},
+			mockSetup: func(m *MockPatientsService, p *models.PatientRequest) {
+				m.On("CreatePatient", mock.Anything, p).Return(nil, errors.New("validation error"))
+			},
+			expectedError:  errors.New("validation error"),
+			expectedResult: nil,
+		},
+		{
+			name: "Success with non-binary gender",
+			patient: &models.PatientRequest{
+				ClientID:       "client789",
+				FirstName:      "Alex",
+				LastName:       "Taylor",
+				DocType:        "DNI",
+				DocNumber:      "98765432",
+				BirthDate:      "1992-03-15",
+				Gender:         "NB",
+				CountryCode:    "54",
+				PhoneNumber:    "5555555555",
+				Email:          "alex.taylor@example.com",
+				AddressStreet:  "Third St",
+				AddressNumber:  "789",
+				AddressCity:    "Another City",
+				AddressCountry: "Country",
+				ZipCode:        "67890",
+				Metadata:       map[string]interface{}{"key3": "value3"},
+			},
+			mockSetup: func(m *MockPatientsService, p *models.PatientRequest) {
+				m.On("CreatePatient", mock.Anything, p).Return(p, nil)
+			},
+			expectedError: nil,
+			expectedResult: &models.PatientRequest{
+				ClientID:       "client789",
+				FirstName:      "Alex",
+				LastName:       "Taylor",
+				DocType:        "DNI",
+				DocNumber:      "98765432",
+				BirthDate:      "1992-03-15",
+				Gender:         "NB",
+				CountryCode:    "54",
+				PhoneNumber:    "5555555555",
+				Email:          "alex.taylor@example.com",
+				AddressStreet:  "Third St",
+				AddressNumber:  "789",
+				AddressCity:    "Another City",
+				AddressCountry: "Country",
+				ZipCode:        "67890",
+				Metadata:       map[string]interface{}{"key3": "value3"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			logger := zaptest.NewLogger(t).Sugar()
+			mockService := new(MockPatientsService)
+			tt.mockSetup(mockService, tt.patient)
+
+			handler := &Patients{
+				Service: mockService,
+				Logger:  logger,
+			}
+
+			// Act
+			result, err := handler.Create(context.Background(), tt.patient)
+
+			// Assert
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError.Error(), err.Error())
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedResult, result)
+			}
+			mockService.AssertExpectations(t)
+		})
+	}
+}
+
+func TestPatients_Get(t *testing.T) {
+	// Sample patient for tests
+	samplePatient := &models.PatientRequest{
+		ClientID:       "client123",
+		FirstName:      "John",
+		LastName:       "Doe",
+		DocType:        "DNI",
+		DocNumber:      "12345678",
+		BirthDate:      "1990-01-01",
+		Gender:         "M",
+		CountryCode:    "54",
+		PhoneNumber:    "1234567890",
+		Email:          "john.doe@example.com",
+		AddressStreet:  "Main St",
+		AddressNumber:  "123",
+		AddressCity:    "City",
+		AddressCountry: "Country",
+		ZipCode:        "12345",
+		Metadata:       map[string]interface{}{"key": "value"},
+	}
+
+	// Test scenarios
+	tests := []struct {
+		name           string
+		request        *models.GetPatientRequest
+		mockSetup      func(*MockPatientsService)
+		expectedError  error
+		expectedResult *models.PatientRequest
+	}{
+		{
+			name:    "Success",
+			request: &models.GetPatientRequest{ID: "user123"},
+			mockSetup: func(m *MockPatientsService) {
+				m.On("GetPatient", mock.Anything, &models.GetPatientRequest{ID: "user123"}).Return(samplePatient, nil)
+			},
+			expectedError:  nil,
+			expectedResult: samplePatient,
+		},
+		{
+			name:    "Not Found",
+			request: &models.GetPatientRequest{ID: "nonexistent"},
+			mockSetup: func(m *MockPatientsService) {
+				m.On("GetPatient", mock.Anything, &models.GetPatientRequest{ID: "nonexistent"}).Return(nil, errors.New("patient not found"))
+			},
+			expectedError:  errors.New("patient not found"),
+			expectedResult: nil,
+		},
+		{
+			name:    "Service Error",
+			request: &models.GetPatientRequest{ID: "user456"},
+			mockSetup: func(m *MockPatientsService) {
+				m.On("GetPatient", mock.Anything, &models.GetPatientRequest{ID: "user456"}).Return(nil, errors.New("service error"))
+			},
+			expectedError:  errors.New("service error"),
+			expectedResult: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			logger := zaptest.NewLogger(t).Sugar()
+			mockService := new(MockPatientsService)
+			tt.mockSetup(mockService)
+
+			handler := &Patients{
+				Service: mockService,
+				Logger:  logger,
+			}
+
+			// Act
+			result, err := handler.Get(context.Background(), tt.request)
+
+			// Assert
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError.Error(), err.Error())
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedResult, result)
+			}
+			mockService.AssertExpectations(t)
+		})
+	}
+}
+
+func TestPatients_Update(t *testing.T) {
+	// Test scenarios
+	tests := []struct {
+		name          string
+		patient       *models.PatientRequest
+		mockSetup     func(*MockPatientsService, *models.PatientRequest)
+		expectedError error
+	}{
+		{
+			name: "Success",
+			patient: &models.PatientRequest{
+				ClientID:  "client123",
+				FirstName: "John",
+				LastName:  "Doe",
+				DocType:   "DNI",
+				DocNumber: "12345678",
+			},
+			mockSetup: func(m *MockPatientsService, p *models.PatientRequest) {
+				m.On("UpdatePatient", mock.Anything, p).Return(nil)
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Service Error",
+			patient: &models.PatientRequest{
+				ClientID:  "client456",
+				FirstName: "Jane",
+				LastName:  "Smith",
+				DocType:   "DNI",
+				DocNumber: "87654321",
+			},
+			mockSetup: func(m *MockPatientsService, p *models.PatientRequest) {
+				m.On("UpdatePatient", mock.Anything, p).Return(errors.New("service error"))
+			},
+			expectedError: errors.New("service error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			logger := zaptest.NewLogger(t).Sugar()
+			mockService := new(MockPatientsService)
+			tt.mockSetup(mockService, tt.patient)
+
+			handler := &Patients{
+				Service: mockService,
+				Logger:  logger,
+			}
+
+			// Act
+			result, err := handler.Update(context.Background(), tt.patient)
+
+			// Assert
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError.Error(), err.Error())
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.patient, result)
+			}
+			mockService.AssertExpectations(t)
+		})
+	}
+}
+
+func TestPatients_Delete(t *testing.T) {
+	// Test scenarios
+	tests := []struct {
+		name          string
+		userID        string
+		mockSetup     func(*MockPatientsService)
+		expectedError error
+	}{
+		{
+			name:   "Success",
+			userID: "user123",
+			mockSetup: func(m *MockPatientsService) {
+				m.On("DeletePatient", mock.Anything, "user123").Return(nil)
+			},
+			expectedError: nil,
+		},
+		{
+			name:   "Not Found",
+			userID: "nonexistent",
+			mockSetup: func(m *MockPatientsService) {
+				m.On("DeletePatient", mock.Anything, "nonexistent").Return(errors.New("patient not found"))
+			},
+			expectedError: errors.New("patient not found"),
+		},
+		{
+			name:   "Service Error",
+			userID: "user456",
+			mockSetup: func(m *MockPatientsService) {
+				m.On("DeletePatient", mock.Anything, "user456").Return(errors.New("service error"))
+			},
+			expectedError: errors.New("service error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			logger := zaptest.NewLogger(t).Sugar()
+			mockService := new(MockPatientsService)
+			tt.mockSetup(mockService)
+
+			handler := &Patients{
+				Service: mockService,
+				Logger:  logger,
+			}
+
+			// Act
+			err := handler.Delete(context.Background(), tt.userID)
+
+			// Assert
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError.Error(), err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+			mockService.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/models/patient.go
+++ b/internal/models/patient.go
@@ -1,5 +1,11 @@
 package models
 
+const (
+	GenderMale      = "M"
+	GenderFemale    = "F"
+	GenderNonBinary = "NB"
+)
+
 type PatientRequest struct {
 	ClientID       string                 `json:"client_id" required:"true"`
 	ID             string                 `json:"id"`

--- a/internal/service/patients/patients_service.go
+++ b/internal/service/patients/patients_service.go
@@ -1,0 +1,253 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/MezeLaw/iris-services/internal/models"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+type PatientsRepository interface {
+	Save(ctx context.Context, p *models.Patient) error
+	GetByID(ctx context.Context, id string) (*models.Patient, error)
+	GetByClientID(ctx context.Context, clientID string) ([]*models.Patient, error)
+	GetByDocument(ctx context.Context, docType, docNumber string) (*models.Patient, error)
+	Delete(ctx context.Context, id string) error
+}
+
+type PatientsService interface {
+	CreatePatient(context.Context, *models.PatientRequest) (*models.PatientRequest, error)
+	GetPatient(context.Context, *models.GetPatientRequest) (*models.PatientRequest, error)
+	GetAllPatients(context.Context, string) ([]*models.PatientRequest, error)
+	UpdatePatient(context.Context, *models.PatientRequest) error
+	DeletePatient(context.Context, string) error
+}
+
+type Patients struct {
+	Logger             *zap.SugaredLogger
+	PatientsRepository PatientsRepository
+}
+
+func New(logger *zap.SugaredLogger, repository PatientsRepository) PatientsService {
+	return &Patients{
+		Logger:             logger,
+		PatientsRepository: repository,
+	}
+}
+
+func (p *Patients) CreatePatient(ctx context.Context, request *models.PatientRequest) (*models.PatientRequest, error) {
+	// Validar género
+	if err := validateGender(request.Gender); err != nil {
+		p.Logger.Error("Invalid gender value", zap.String("gender", request.Gender))
+		return nil, err
+	}
+
+	patient := p.mapRequestToPatient(request)
+	if err := p.PatientsRepository.Save(ctx, patient); err != nil {
+		p.Logger.Error("Error on PatientsRepository.Save", zap.Error(err))
+		return nil, err
+	}
+	return request, nil
+}
+
+func (p *Patients) GetPatient(ctx context.Context, params *models.GetPatientRequest) (*models.PatientRequest, error) {
+	// Si se proporciona un ID, buscar por ID
+	if params.ID != "" {
+		p.Logger.Info("Getting patient by ID", zap.String("id", params.ID))
+		patient, err := p.PatientsRepository.GetByID(ctx, params.ID)
+		if err != nil {
+			p.Logger.Error("Error getting patient by ID", zap.String("id", params.ID), zap.Error(err))
+			return nil, err
+		}
+		return p.mapPatientToRequest(patient), nil
+	}
+
+	// Si se proporcionan DocType y DocNumber, buscar por documento
+	if params.DocType != "" && params.DocNumber != "" {
+		p.Logger.Info("Getting patient by Document",
+			zap.String("docType", params.DocType),
+			zap.String("docNumber", params.DocNumber))
+
+		patient, err := p.PatientsRepository.GetByDocument(ctx, params.DocType, params.DocNumber)
+		if err != nil {
+			p.Logger.Error("Error getting patient by Document",
+				zap.String("docType", params.DocType),
+				zap.String("docNumber", params.DocNumber),
+				zap.Error(err))
+			return nil, err
+		}
+
+		return p.mapPatientToRequest(patient), nil
+	}
+
+	// Si no se proporcionó ningún parámetro válido para la búsqueda
+	p.Logger.Error("Invalid parameters for GetPatient")
+	return nil, fmt.Errorf("invalid parameters: must provide ID, ClientID, or DocType/DocNumber")
+}
+
+func (p *Patients) GetAllPatients(ctx context.Context, identifier string) ([]*models.PatientRequest, error) {
+	// Verificar que el identificador no esté vacío
+	if identifier == "" {
+		p.Logger.Error("Error: empty client-id provided to GetAllPatients")
+		return nil, fmt.Errorf("client-id cannot be empty")
+	}
+
+	p.Logger.Info("Getting all patients by ClientID", zap.String("clientID", identifier))
+
+	// Obtener pacientes del repositorio usando el cliente ID
+	patients, err := p.PatientsRepository.GetByClientID(ctx, identifier)
+	if err != nil {
+		p.Logger.Error("Error getting patients by ClientID", zap.String("clientID", identifier), zap.Error(err))
+		return nil, err
+	}
+
+	// Mapear los pacientes del modelo de BD al modelo de request
+	patientRequests := make([]*models.PatientRequest, 0, len(patients))
+	for _, patient := range patients {
+		patientRequests = append(patientRequests, p.mapPatientToRequest(patient))
+	}
+
+	p.Logger.Info("Successfully retrieved patients", zap.Int("count", len(patientRequests)))
+	return patientRequests, nil
+}
+
+func (p *Patients) UpdatePatient(ctx context.Context, request *models.PatientRequest) error {
+	// Verificar que el paciente tenga un ID
+	if request.ID == "" {
+		p.Logger.Error("Error: Missing patient ID for update")
+		return fmt.Errorf("patient ID is required for update")
+	}
+
+	// Validar género
+	if err := validateGender(request.Gender); err != nil {
+		p.Logger.Error("Invalid gender value", zap.String("gender", request.Gender))
+		return err
+	}
+
+	p.Logger.Info("Updating patient", zap.String("id", request.ID))
+
+	// Obtener el paciente existente
+	existingPatient, err := p.PatientsRepository.GetByID(ctx, request.ID)
+	if err != nil {
+		p.Logger.Error("Error fetching patient to update", zap.String("id", request.ID), zap.Error(err))
+		return fmt.Errorf("failed to find patient with ID %s: %w", request.ID, err)
+	}
+
+	// Actualizar los campos del paciente existente
+	updatedPatient := &models.Patient{
+		ID:             existingPatient.ID,
+		ClientID:       request.ClientID,
+		FirstName:      request.FirstName,
+		LastName:       request.LastName,
+		DocType:        request.DocType,
+		DocNumber:      request.DocNumber,
+		BirthDate:      request.BirthDate,
+		Gender:         request.Gender,
+		CountryCode:    request.CountryCode,
+		PhoneNumber:    request.PhoneNumber,
+		Email:          request.Email,
+		AddressStreet:  request.AddressStreet,
+		AddressNumber:  request.AddressNumber,
+		AddressCity:    request.AddressCity,
+		AddressCountry: request.AddressCountry,
+		ZipCode:        request.ZipCode,
+		CreatedAt:      existingPatient.CreatedAt,
+		UpdatedAt:      time.Now().Format(time.RFC3339),
+		Metadata:       request.Metadata,
+	}
+
+	// Guardar el paciente actualizado
+	if err := p.PatientsRepository.Save(ctx, updatedPatient); err != nil {
+		p.Logger.Error("Error updating patient", zap.String("id", request.ID), zap.Error(err))
+		return fmt.Errorf("failed to update patient: %w", err)
+	}
+
+	p.Logger.Info("Patient updated successfully", zap.String("id", request.ID))
+	return nil
+}
+
+func (p *Patients) DeletePatient(ctx context.Context, id string) error {
+	// Verificar que el ID no esté vacío
+	if id == "" {
+		p.Logger.Error("Error: empty ID provided for patient deletion")
+		return fmt.Errorf("patient ID cannot be empty")
+	}
+
+	p.Logger.Info("Deleting patient", zap.String("id", id))
+
+	// Verificar primero si el paciente existe
+	_, err := p.PatientsRepository.GetByID(ctx, id)
+	if err != nil {
+		p.Logger.Error("Error finding patient to delete", zap.String("id", id), zap.Error(err))
+		return fmt.Errorf("failed to find patient with ID %s: %w", id, err)
+	}
+
+	// Eliminar el paciente
+	if err := p.PatientsRepository.Delete(ctx, id); err != nil {
+		p.Logger.Error("Error deleting patient", zap.String("id", id), zap.Error(err))
+		return fmt.Errorf("failed to delete patient: %w", err)
+	}
+
+	p.Logger.Info("Patient deleted successfully", zap.String("id", id))
+	return nil
+}
+
+func (p *Patients) mapRequestToPatient(req *models.PatientRequest) *models.Patient {
+	return &models.Patient{
+		ID:             uuid.NewString(),
+		ClientID:       req.ClientID,
+		FirstName:      req.FirstName,
+		LastName:       req.LastName,
+		DocType:        req.DocType,
+		DocNumber:      req.DocNumber,
+		BirthDate:      req.BirthDate,
+		Gender:         req.Gender,
+		CountryCode:    req.CountryCode,
+		PhoneNumber:    req.PhoneNumber,
+		Email:          req.Email,
+		AddressStreet:  req.AddressStreet,
+		AddressNumber:  req.AddressNumber,
+		AddressCity:    req.AddressCity,
+		AddressCountry: req.AddressCountry,
+		ZipCode:        req.ZipCode,
+		CreatedAt:      time.Now().Format(time.RFC3339),
+		UpdatedAt:      time.Now().Format(time.RFC3339),
+		Metadata:       req.Metadata,
+	}
+}
+
+func (p *Patients) mapPatientToRequest(patient *models.Patient) *models.PatientRequest {
+	return &models.PatientRequest{
+		ClientID:       patient.ClientID,
+		ID:             patient.ID,
+		FirstName:      patient.FirstName,
+		LastName:       patient.LastName,
+		DocType:        patient.DocType,
+		DocNumber:      patient.DocNumber,
+		BirthDate:      patient.BirthDate,
+		Gender:         patient.Gender,
+		CountryCode:    patient.CountryCode,
+		PhoneNumber:    patient.PhoneNumber,
+		Email:          patient.Email,
+		AddressStreet:  patient.AddressStreet,
+		AddressNumber:  patient.AddressNumber,
+		AddressCity:    patient.AddressCity,
+		AddressCountry: patient.AddressCountry,
+		ZipCode:        patient.ZipCode,
+		CreatedAt:      patient.CreatedAt,
+		UpdatedAt:      patient.UpdatedAt,
+		Metadata:       patient.Metadata,
+	}
+}
+
+func validateGender(gender string) error {
+	switch gender {
+	case models.GenderMale, models.GenderFemale, models.GenderNonBinary:
+		return nil
+	default:
+		return fmt.Errorf("invalid gender value: %s. Must be one of: %s, %s, %s", gender, models.GenderMale, models.GenderFemale, models.GenderNonBinary)
+	}
+}


### PR DESCRIPTION
This PR implements a consistent gender validation across all service layers.

Changes include:
- Add gender constants in models package (M, F, NB)
- Implement gender validation in both handler and service layers
- Add consistent error messages for invalid gender values
- Support for M (Male), F (Female), and NB (Non-Binary) genders

The validation is now consistently applied in both creation and update operations, with clear error messages when an invalid gender value is provided.